### PR TITLE
Use mp.utils.getpid()

### DIFF
--- a/mpvSockets.lua
+++ b/mpvSockets.lua
@@ -3,17 +3,6 @@
 local utils = require 'mp.utils'
 tempDir = "/tmp"
 
-function os.capture(cmd, raw)
-  local f = assert(io.popen(cmd, 'r'))
-  local s = assert(f:read('*a'))
-  f:close()
-  if raw then return s end
-  s = string.gsub(s, '^%s+', '')
-  s = string.gsub(s, '%s+$', '')
-  s = string.gsub(s, '[\n\r]+', ' ')
-  return s
-end
-
 function join_paths(...)
     local arg={...}
     path = ""
@@ -23,7 +12,7 @@ function join_paths(...)
     return path;
 end
 
-ppid = os.capture("stat=($(</proc/$$/stat)) && echo \"${stat[3]}\"", false)
+ppid = utils.getpid()
 os.execute("mkdir " .. join_paths(tempDir, "mpvSockets") .. " 2>/dev/null")
 mp.set_property("options/input-ipc-server", join_paths(tempDir, "mpvSockets", ppid))
 


### PR DESCRIPTION
As of https://github.com/mpv-player/mpv/pull/5245 you get the pid in an easier way.

Thanks for making this script by the way, it was exactly what I was looking for!